### PR TITLE
Offers and configurable LIT node

### DIFF
--- a/src/ContractAddDialog.js
+++ b/src/ContractAddDialog.js
@@ -51,10 +51,12 @@ class ContractAddDialog extends React.Component {
     settleUnix: 0,
     amount: 0,
     price: 0,
-    satPrice: 0
+    satPrice: 0,
+    peerIdx: 0
   };
 
   handleClickOpen = (event) => {
+    this.handleDateChange(new Date());
     this.setState({menuAnchorEl : event.target});
   };
 
@@ -63,7 +65,7 @@ class ContractAddDialog extends React.Component {
   };
 
   handleSubmit = () => {
-    this.props.handleCreateContract(this.state.imSelling, this.state.asset, this.state.amount, this.state.satPrice, this.state.settleUnix)
+    this.props.handleCreateContract(this.state.imSelling, this.state.asset, parseFloat(this.state.amount), this.state.satPrice, this.state.settleUnix, this.state.peerIdx)
     this.setState({open: false});
   };
 
@@ -120,6 +122,12 @@ class ContractAddDialog extends React.Component {
     });
   }
 
+  handlePeerChange = event => {
+    this.setState({peerIdx : event.target.value});
+
+  }
+
+
   handleDateChange = (date) => {
     var epoch = Math.floor(date.getTime()/1000);
     epoch = Math.round(epoch/300) * 300; // round to 5 minute interval
@@ -147,7 +155,7 @@ class ContractAddDialog extends React.Component {
 
   render() {
     const {classes} = this.props;
-    const {menuAnchorEl, settleDate, asset, imSelling, amount, price, priceType} = this.state;
+    const {menuAnchorEl, peerIdx, settleDate, asset, imSelling, amount, price, priceType} = this.state;
 
     return (
       <div>
@@ -279,6 +287,30 @@ class ContractAddDialog extends React.Component {
                     <MenuItem value={1}>BTC per {this.props.assets[asset] ? this.props.assets[asset].name : ""}</MenuItem>
                   </Select>
                   </FormControl>
+              </Grid>
+            </Grid>
+          </DialogContent>
+          <DialogContent>
+            <Grid container spacing={8}>
+              <Grid item xs={12}>
+              
+                <FormControl id="peerfc" className={classes.formControl}>
+                  <InputLabel>Peer</InputLabel>
+                    <Select 
+                      inputProps={{
+                        name: 'peer',
+                        id: 'peer',
+                      }} 
+                      fullWidth
+                      value={peerIdx} 
+                      onChange={this.handlePeerChange}>
+                      {this.props.connections.map((conn, index) => (
+                        <MenuItem value={conn.PeerNumber}>{
+                          conn.Nickname === '' ? 'Peer ' + conn.PeerNumber.toString() : conn.Nickname
+                        }</MenuItem>
+                      ))}
+                    </Select>
+                </FormControl>
               </Grid>
             </Grid>
           </DialogContent>

--- a/src/Contracts.js
+++ b/src/Contracts.js
@@ -9,6 +9,7 @@ import Zoom from 'material-ui/transitions/Zoom';
 
 import ContractCard from './ContractCard.js'
 import ContractAddDialog from './ContractAddDialog.js'
+import OfferCard from './OfferCard.js'
 
 const styles = theme => ({
   root: {
@@ -46,6 +47,16 @@ const styles = theme => ({
 function Contracts(props) {
   const {classes} = props;
 
+  let offers = props.offers.map((offer, index) => {
+    return (
+      <Zoom in key={offer.OIdx}>
+        <Grid item xs={3} className={classes.cardBox}>
+          <OfferCard offer={offer} handleOfferCommand={props.handleOfferCommand}/>
+        </Grid>
+      </Zoom>
+    );
+  });
+
   let contracts = props.contracts.map((contract, index) => {
       return (
         <Zoom in key={contract.Idx}>
@@ -60,11 +71,12 @@ function Contracts(props) {
     <div className={classes.root}>
       <div className={classes.peerGroup}>
         <Grid container>
+          {offers}
           {contracts}
           <Zoom in key="AddDialog">
             <Grid item xs={4} className={classes.addButtonBox}>
               <ContractAddDialog
-                peerIndex={props.peerIndex}
+                connections={props.connections}
                 handleCreateContract={props.handleCreateContract}
                 assets={props.assets}
                 fetchAssetValue={props.fetchAssetValue}
@@ -79,7 +91,10 @@ function Contracts(props) {
 
 Contracts.propTypes = {
   contracts: PropTypes.array.isRequired,
+  connections: PropTypes.array.isRequired,
   handleCreateContract: PropTypes.func.isRequired,
+  handleOfferCommand: PropTypes.func.isRequired,
+  offers: PropTypes.array.isRequired,
   fetchAssetValue: PropTypes.func.isRequired,
   assets: PropTypes.array.isRequired
 };

--- a/src/OfferCard.css
+++ b/src/OfferCard.css
@@ -1,0 +1,13 @@
+
+.Highlight {
+    animation: Highlight infinite .4s linear;
+}
+
+
+@keyframes Highlight {
+    0% { transform: scale(1.0, 1.0); }
+    25% { transform: scale(1.0, 1.2); }
+    50% { transform: scale(1.0, 1.0); }
+    75% { transform: scale(1.0, 1.2); }
+    100% { transform: scale(1.0, 1.0); }
+}

--- a/src/OfferCard.js
+++ b/src/OfferCard.js
@@ -1,0 +1,107 @@
+/**
+ * Created by joe on 4/11/18.
+ */
+import React from 'react';
+import PropTypes from 'prop-types';
+import {withStyles} from 'material-ui/styles';
+import Card, {CardActions, CardContent, CardHeader} from 'material-ui/Card';
+import Button from 'material-ui/Button';
+import Chip from 'material-ui/Chip';
+import './ContractCard.css' // highlight css style (@keyframes can't be done in MUI styles)
+
+const styles = theme => ({
+  tool: {
+    display: 'flex',
+  },
+  card: {},
+  cardDisabled: {
+    minWidth: 240,
+    backgroundColor: 'lightGrey',
+  },
+  balance: {
+    fontSize: 14,
+  },
+  actions: {
+    display: 'flex',
+  },
+  offer: {
+    marginLeft: 'auto',
+  },
+  settle: {
+    marginLeft: 'auto',
+  },
+  accept: {
+    marginLeft: 'auto',
+  },
+  decline: {
+    marginLeft: 'auto',
+  },
+  divider: {}
+});
+
+
+/*
+ * Main ChannelCard component
+ */
+class OfferCard extends React.Component {
+
+  state = {
+    myBalance: 0,
+    highlight: false,
+  };
+
+
+  handleAccept() {
+    this.props.handleOfferCommand(this.props.offer, 'accept');
+  }
+
+  handleDecline() {
+    this.props.handleOfferCommand(this.props.offer, 'decline');
+  }
+
+
+  componentWillReceiveProps(nextProps) {
+    
+  }
+
+  render() {
+
+    const {classes} = this.props;
+   
+    let acceptButton, declineButton; // React components
+
+    acceptButton = (
+      <Button className={classes.settle} onClick={this.handleAccept.bind(this)}>Accept</Button>
+    );
+    declineButton = (
+      <Button className={classes.settle} onClick={this.handleDecline.bind(this)}>Decline</Button>
+    );
+      
+    console.log(this.props.contract);
+
+    return (
+      <div className={classes.cardBox}>
+        <Card raised={true} className={classes.card}>
+          <CardHeader title={"Offer " + this.props.offer.OIdx}
+                      />
+          <CardContent>
+            Received from peer {this.props.offer.PeerIdx}
+          </CardContent>
+          <CardActions className={classes.action} disableActionSpacing>
+          
+            {acceptButton}
+            {declineButton}
+          </CardActions>
+        </Card>
+      </div>
+    );
+  }
+}
+
+OfferCard.propTypes = {
+  classes: PropTypes.object.isRequired,
+  offer: PropTypes.object.isRequired,
+  handleOfferCommand: PropTypes.func,
+};
+
+export default withStyles(styles)(OfferCard);


### PR DESCRIPTION
I added the concept of "Offers" to the UI and the creation and acceptance of them in RPC calls. It's still a work in progress, but it allows you to create Forward contracts, and accept them on the other node.

Also, added the ability to specify the LIT node we're connecting to from the URL. So if you open http://localhost:3000/?host={host}&port={port} it will connect to that RPC endpoint. Defaults to localhost/8001 if not specified.