### PR TITLE
Need to send params as array

### DIFF
--- a/src/LitClient.js
+++ b/src/LitClient.js
@@ -39,6 +39,9 @@ class LitAfClient {
     let id = requestNonce++;
     let promise = new Promise((resolve, reject) => {
       this.waitForConnection.then(() => {
+        if (args !== null) {
+          args = [args];
+        }
         let json = JSON.stringify({'method': method, 'params': args, 'id': id});
         console.log("RPC Send: " + json);
         this.rpccon.send(json);


### PR DESCRIPTION
The parameters need to be an array as per JSONRPC standards. That's why it wasn't recognizing them